### PR TITLE
fix: readme: link to MCP webpage

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,5 @@
 
 *This project is being bootstrapped, the README is a bit bare for the moment*.
 
-This project provides a [Model Context Protocol](mcp) server for the tektoncd projects.
+This project provides a [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server for the tektoncd projects.
 It initially focuses on [`tektoncd/pipeline`](https://github.com/tektoncd/pipeline) objects but will over time add support for other tektoncd projects.
-
-
-[mcp]: https://modelcontextprotocol.io/


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
* the link to the https://modelcontextprotocol.io webpage was not visible in the readme
