### PR TITLE
fix: FIXME in main.go that was using a hardcoded version string

### DIFF
--- a/cmd/tekton-mcp-server/main.go
+++ b/cmd/tekton-mcp-server/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 	"github.com/tektoncd/mcp-server/internal/resources"
 	"github.com/tektoncd/mcp-server/internal/tools"
+	"github.com/tektoncd/mcp-server/internal/version"
 	"k8s.io/client-go/tools/clientcmd"
 	filteredinformerfactory "knative.dev/pkg/client/injection/kube/informers/factory/filtered"
 	"knative.dev/pkg/injection"
@@ -36,7 +37,7 @@ func main() {
 	// Create MCP server
 	s := server.NewMCPServer(
 		"Tekton",
-		"0.0.1", // FIXME get this from internal package
+		version.Version,
 		server.WithResourceCapabilities(true, true),
 		server.WithPromptCapabilities(true),
 		server.WithToolCapabilities(true),

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,4 @@
+package version
+
+// Version is the current version of the Tekton MCP Server.
+var Version = "0.0.1"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
- Created `internal/version/version.go` with a Version constant
- Updated main.go to use the version package

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
The version is now maintained in a single location, making it easier to update in the future.
```
