### PR TITLE
feat: Add comprehensive CRUD operations for Tekton resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,47 +7,133 @@ It initially focuses on [`tektoncd/pipeline`](https://github.com/tektoncd/pipeli
 
 ## Tools
 
+### List Operations
+
 #### `list_pipelines` – List Pipelines in the Cluster with Filtering Options
 - `namespace`: Namespace to list Pipelines from (string, required)
 - `prefix`: Name prefix to filter Pipelines (string, optional)
 - `label-selector`: Label selector to filter Pipelines (string, optional)
-
-#### `start_pipeline` – Start a Pipeline
-- `name`: Name or reference of the Pipeline to start (string, required)
-- `namespace`: Namespace where the Pipeline is located (string, optional, default: "default")
 
 #### `list_pipeline_runs` – List PipelineRuns in the Cluster with Filtering Options
 - `namespace`: Namespace to list PipelineRuns from (string, required)
 - `prefix`: Name prefix to filter PipelineRuns (string, optional)
 - `label-selector`: Label selector to filter PipelineRuns (string, optional)
 
-#### `restart_pipelinerun` – Restart a PipelineRun
-- `name`: Name or reference of the PipelineRun to restart (string, required)
-- `namespace`: Namespace where the PipelineRun is located (string, optional, default: "default")
-
 #### `list_tasks` – List Tasks in the Cluster with Filtering Options
 - `namespace`: Namespace to list Tasks from (string, required)
 - `prefix`: Name prefix to filter Tasks (string, optional)
 - `label-selector`: Label selector to filter Tasks (string, optional)
-
-#### `start_task` – Start a Task
-- `name`: Name or reference of the Task to start (string, required)
-- `namespace`: Namespace where the Task is located (string, optional, default: "default")
 
 #### `list_task_runs` – List TaskRuns in the Cluster with Filtering Options
 - `namespace`: Namespace to list TaskRuns from (string, required)
 - `prefix`: Name prefix to filter TaskRuns (string, optional)
 - `label-selector`: Label selector to filter TaskRuns (string, optional)
 
-#### `restart_taskrun` – Restart a TaskRun
-- `name`: Name or reference of the TaskRun to restart (string, required)
-- `namespace`: Namespace where the TaskRun is located (string, optional, default: "default")
-
 #### `list_stepactions` – List Step Actions in the Cluster with Filtering Options
 - `namespace`: Namespace to list Step Actions from (string, required)
 - `prefix`: Name prefix to filter Step Actions (string, optional)
 - `label-selector`: Label selector to filter Step Actions (string, optional)
 
+### Create Operations
+
+#### `create_pipeline` – Create a new Pipeline from YAML definition
+- `namespace`: Namespace where the Pipeline will be created (string, optional, default: "default")
+- `yaml`: YAML definition of the Pipeline (string, required)
+
+#### `create_task` – Create a new Task from YAML definition
+- `namespace`: Namespace where the Task will be created (string, optional, default: "default")
+- `yaml`: YAML definition of the Task (string, required)
+
+#### `create_pipelinerun` – Create a new PipelineRun from YAML definition or generate from Pipeline
+- `namespace`: Namespace where the PipelineRun will be created (string, optional, default: "default")
+- `yaml`: YAML definition of the PipelineRun (string, optional)
+- `generateName`: Generate name prefix for the PipelineRun (string, optional)
+
+#### `create_taskrun` – Create a new TaskRun from YAML definition
+- `namespace`: Namespace where the TaskRun will be created (string, optional, default: "default")
+- `yaml`: YAML definition of the TaskRun (string, optional)
+- `generateName`: Generate name prefix for the TaskRun (string, optional)
+
+### Get Operations
+
+#### `get_pipeline` – Get a specific Pipeline by name
+- `name`: Name of the Pipeline to get (string, required)
+- `namespace`: Namespace of the Pipeline (string, optional, default: "default")
+- `output`: Output format - json or yaml (string, optional, default: "yaml")
+
+#### `get_task` – Get a specific Task by name
+- `name`: Name of the Task to get (string, required)
+- `namespace`: Namespace of the Task (string, optional, default: "default")
+- `output`: Output format - json or yaml (string, optional, default: "yaml")
+
+#### `get_pipelinerun` – Get a specific PipelineRun by name
+- `name`: Name of the PipelineRun to get (string, required)
+- `namespace`: Namespace of the PipelineRun (string, optional, default: "default")
+- `output`: Output format - json or yaml (string, optional, default: "yaml")
+
+#### `get_taskrun` – Get a specific TaskRun by name
+- `name`: Name of the TaskRun to get (string, required)
+- `namespace`: Namespace of the TaskRun (string, optional, default: "default")
+- `output`: Output format - json or yaml (string, optional, default: "yaml")
+
 #### `get_taskrun_logs` - Get the logs for a given TaskRun
+- `name`: Name or reference of the TaskRun to get logs from (string, required)
+- `namespace`: Namespace where the TaskRun is located (string, optional, default: "default")
+
+### Update Operations
+
+#### `update_pipeline` – Update an existing Pipeline
+- `name`: Name of the Pipeline to update (string, required)
+- `namespace`: Namespace of the Pipeline (string, optional, default: "default")
+- `yaml`: Updated YAML definition of the Pipeline (string, required)
+
+#### `update_task` – Update an existing Task
+- `name`: Name of the Task to update (string, required)
+- `namespace`: Namespace of the Task (string, optional, default: "default")
+- `yaml`: Updated YAML definition of the Task (string, required)
+
+#### `patch_pipeline` – Apply a JSON patch to an existing Pipeline
+- `name`: Name of the Pipeline to patch (string, required)
+- `namespace`: Namespace of the Pipeline (string, optional, default: "default")
+- `patch`: JSON patch to apply to the Pipeline (string, required)
+
+### Delete Operations
+
+#### `delete_pipeline` – Delete a Pipeline
+- `name`: Name of the Pipeline to delete (string, required)
+- `namespace`: Namespace of the Pipeline (string, optional, default: "default")
+
+#### `delete_task` – Delete a Task
+- `name`: Name of the Task to delete (string, required)
+- `namespace`: Namespace of the Task (string, optional, default: "default")
+
+#### `delete_pipelinerun` – Delete a PipelineRun
+- `name`: Name of the PipelineRun to delete (string, required)
+- `namespace`: Namespace of the PipelineRun (string, optional, default: "default")
+
+#### `delete_taskrun` – Delete a TaskRun
+- `name`: Name of the TaskRun to delete (string, required)
+- `namespace`: Namespace of the TaskRun (string, optional, default: "default")
+
+#### `delete_all_pipelineruns` – Delete multiple PipelineRuns based on selectors
+- `namespace`: Namespace to delete PipelineRuns from (string, optional, default: "default")
+- `labelSelector`: Label selector to filter PipelineRuns to delete (string, optional)
+- `fieldSelector`: Field selector to filter PipelineRuns to delete (string, optional)
+
+### Start/Restart Operations
+
+#### `start_pipeline` – Start a Pipeline
+- `name`: Name or reference of the Pipeline to start (string, required)
+- `namespace`: Namespace where the Pipeline is located (string, optional, default: "default")
+
+#### `start_task` – Start a Task
+- `name`: Name or reference of the Task to start (string, required)
+- `namespace`: Namespace where the Task is located (string, optional, default: "default")
+
+#### `restart_pipelinerun` – Restart a PipelineRun
+- `name`: Name or reference of the PipelineRun to restart (string, required)
+- `namespace`: Namespace where the PipelineRun is located (string, optional, default: "default")
+
+#### `restart_taskrun` – Restart a TaskRun
 - `name`: Name or reference of the TaskRun to restart (string, required)
 - `namespace`: Namespace where the TaskRun is located (string, optional, default: "default")

--- a/internal/tools/create.go
+++ b/internal/tools/create.go
@@ -1,0 +1,260 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/jsonschema"
+	mcp "github.com/modelcontextprotocol/go-sdk/mcp"
+	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	pipelineclient "github.com/tektoncd/pipeline/pkg/client/injection/client"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+)
+
+type createPipelineParams struct {
+	Namespace string `json:"namespace"`
+	Yaml      string `json:"yaml"`
+}
+
+func createPipeline() (*mcp.ServerTool, error) {
+	scheme, err := jsonschema.For[createPipelineParams]()
+	if err != nil {
+		return nil, err
+	}
+
+	scheme.Properties["namespace"].Description = "Namespace where the Pipeline will be created"
+	scheme.Properties["namespace"].Default = json.RawMessage(`"default"`)
+	scheme.Properties["yaml"].Description = "YAML definition of the Pipeline"
+	scheme.Required = []string{"yaml"}
+
+	return mcp.NewServerTool(
+		"create_pipeline",
+		"Create a new Pipeline from YAML definition",
+		handlerCreatePipeline,
+		mcp.Input(mcp.Schema(scheme)),
+	), nil
+}
+
+func handlerCreatePipeline(
+	ctx context.Context,
+	_ *mcp.ServerSession,
+	params *mcp.CallToolParamsFor[createPipelineParams],
+) (*mcp.CallToolResultFor[string], error) {
+	namespace := params.Arguments.Namespace
+	if namespace == "" {
+		namespace = defaultNamespace
+	}
+	yamlStr := params.Arguments.Yaml
+
+	if yamlStr == "" {
+		return result("Error: YAML definition is required"), nil
+	}
+
+	var pipeline pipelinev1.Pipeline
+	if err := yaml.Unmarshal([]byte(yamlStr), &pipeline); err != nil {
+		return result(fmt.Sprintf("Error parsing YAML: %v", err)), nil
+	}
+
+	pipelineClient := pipelineclient.Get(ctx)
+	created, err := pipelineClient.TektonV1().Pipelines(namespace).Create(ctx, &pipeline, metav1.CreateOptions{})
+	if err != nil {
+		return result(fmt.Sprintf("Error creating Pipeline: %v", err)), nil
+	}
+
+	return result(fmt.Sprintf("Pipeline '%s' created successfully in namespace '%s'", created.Name, namespace)), nil
+}
+
+type createTaskParams struct {
+	Namespace string `json:"namespace"`
+	Yaml      string `json:"yaml"`
+}
+
+func createTask() (*mcp.ServerTool, error) {
+	scheme, err := jsonschema.For[createTaskParams]()
+	if err != nil {
+		return nil, err
+	}
+
+	scheme.Properties["namespace"].Description = "Namespace where the Task will be created"
+	scheme.Properties["namespace"].Default = json.RawMessage(`"default"`)
+	scheme.Properties["yaml"].Description = "YAML definition of the Task"
+	scheme.Required = []string{"yaml"}
+
+	return mcp.NewServerTool(
+		"create_task",
+		"Create a new Task from YAML definition",
+		handlerCreateTask,
+		mcp.Input(mcp.Schema(scheme)),
+	), nil
+}
+
+func handlerCreateTask(
+	ctx context.Context,
+	_ *mcp.ServerSession,
+	params *mcp.CallToolParamsFor[createTaskParams],
+) (*mcp.CallToolResultFor[string], error) {
+	namespace := params.Arguments.Namespace
+	if namespace == "" {
+		namespace = defaultNamespace
+	}
+	yamlStr := params.Arguments.Yaml
+
+	if yamlStr == "" {
+		return result("Error: YAML definition is required"), nil
+	}
+
+	var task pipelinev1.Task
+	if err := yaml.Unmarshal([]byte(yamlStr), &task); err != nil {
+		return result(fmt.Sprintf("Error parsing YAML: %v", err)), nil
+	}
+
+	pipelineClient := pipelineclient.Get(ctx)
+	created, err := pipelineClient.TektonV1().Tasks(namespace).Create(ctx, &task, metav1.CreateOptions{})
+	if err != nil {
+		return result(fmt.Sprintf("Error creating Task: %v", err)), nil
+	}
+
+	return result(fmt.Sprintf("Task '%s' created successfully in namespace '%s'", created.Name, namespace)), nil
+}
+
+type createPipelineRunParams struct {
+	Namespace    string `json:"namespace"`
+	Yaml         string `json:"yaml"`
+	GenerateName string `json:"generateName"`
+}
+
+func createPipelineRun() (*mcp.ServerTool, error) {
+	scheme, err := jsonschema.For[createPipelineRunParams]()
+	if err != nil {
+		return nil, err
+	}
+
+	scheme.Properties["namespace"].Description = "Namespace where the PipelineRun will be created"
+	scheme.Properties["namespace"].Default = json.RawMessage(`"default"`)
+	scheme.Properties["yaml"].Description = "YAML definition of the PipelineRun"
+	scheme.Properties["generateName"].Description = "Generate name prefix for the PipelineRun (alternative to fixed name)"
+
+	return mcp.NewServerTool(
+		"create_pipelinerun",
+		"Create a new PipelineRun from YAML definition or generate from Pipeline",
+		handlerCreatePipelineRun,
+		mcp.Input(mcp.Schema(scheme)),
+	), nil
+}
+
+func handlerCreatePipelineRun(
+	ctx context.Context,
+	_ *mcp.ServerSession,
+	params *mcp.CallToolParamsFor[createPipelineRunParams],
+) (*mcp.CallToolResultFor[string], error) {
+	namespace := params.Arguments.Namespace
+	if namespace == "" {
+		namespace = defaultNamespace
+	}
+	yamlStr := params.Arguments.Yaml
+	generateName := params.Arguments.GenerateName
+
+	if yamlStr == "" && generateName == "" {
+		return result("Error: Either YAML definition or generateName is required"), nil
+	}
+
+	pipelineClient := pipelineclient.Get(ctx)
+
+	if yamlStr != "" {
+		var pipelineRun pipelinev1.PipelineRun
+		if err := yaml.Unmarshal([]byte(yamlStr), &pipelineRun); err != nil {
+			return result(fmt.Sprintf("Error parsing YAML: %v", err)), nil
+		}
+
+		created, err := pipelineClient.TektonV1().PipelineRuns(namespace).Create(ctx, &pipelineRun, metav1.CreateOptions{})
+		if err != nil {
+			return result(fmt.Sprintf("Error creating PipelineRun: %v", err)), nil
+		}
+		return result(fmt.Sprintf("PipelineRun '%s' created successfully in namespace '%s'", created.Name, namespace)), nil
+	}
+
+	pipelineRun := &pipelinev1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: generateName,
+		},
+	}
+
+	created, err := pipelineClient.TektonV1().PipelineRuns(namespace).Create(ctx, pipelineRun, metav1.CreateOptions{})
+	if err != nil {
+		return result(fmt.Sprintf("Error creating PipelineRun: %v", err)), nil
+	}
+
+	return result(fmt.Sprintf("PipelineRun '%s' created successfully in namespace '%s'", created.Name, namespace)), nil
+}
+
+type createTaskRunParams struct {
+	Namespace    string `json:"namespace"`
+	Yaml         string `json:"yaml"`
+	GenerateName string `json:"generateName"`
+}
+
+func createTaskRun() (*mcp.ServerTool, error) {
+	scheme, err := jsonschema.For[createTaskRunParams]()
+	if err != nil {
+		return nil, err
+	}
+
+	scheme.Properties["namespace"].Description = "Namespace where the TaskRun will be created"
+	scheme.Properties["namespace"].Default = json.RawMessage(`"default"`)
+	scheme.Properties["yaml"].Description = "YAML definition of the TaskRun"
+	scheme.Properties["generateName"].Description = "Generate name prefix for the TaskRun (alternative to fixed name)"
+
+	return mcp.NewServerTool(
+		"create_taskrun",
+		"Create a new TaskRun from YAML definition",
+		handlerCreateTaskRun,
+		mcp.Input(mcp.Schema(scheme)),
+	), nil
+}
+
+func handlerCreateTaskRun(
+	ctx context.Context,
+	_ *mcp.ServerSession,
+	params *mcp.CallToolParamsFor[createTaskRunParams],
+) (*mcp.CallToolResultFor[string], error) {
+	namespace := params.Arguments.Namespace
+	if namespace == "" {
+		namespace = defaultNamespace
+	}
+	yamlStr := params.Arguments.Yaml
+	generateName := params.Arguments.GenerateName
+
+	if yamlStr == "" && generateName == "" {
+		return result("Error: Either YAML definition or generateName is required"), nil
+	}
+
+	pipelineClient := pipelineclient.Get(ctx)
+
+	if yamlStr != "" {
+		var taskRun pipelinev1.TaskRun
+		if err := yaml.Unmarshal([]byte(yamlStr), &taskRun); err != nil {
+			return result(fmt.Sprintf("Error parsing YAML: %v", err)), nil
+		}
+
+		created, err := pipelineClient.TektonV1().TaskRuns(namespace).Create(ctx, &taskRun, metav1.CreateOptions{})
+		if err != nil {
+			return result(fmt.Sprintf("Error creating TaskRun: %v", err)), nil
+		}
+		return result(fmt.Sprintf("TaskRun '%s' created successfully in namespace '%s'", created.Name, namespace)), nil
+	}
+
+	taskRun := &pipelinev1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: generateName,
+		},
+	}
+
+	created, err := pipelineClient.TektonV1().TaskRuns(namespace).Create(ctx, taskRun, metav1.CreateOptions{})
+	if err != nil {
+		return result(fmt.Sprintf("Error creating TaskRun: %v", err)), nil
+	}
+
+	return result(fmt.Sprintf("TaskRun '%s' created successfully in namespace '%s'", created.Name, namespace)), nil
+}

--- a/internal/tools/create_test.go
+++ b/internal/tools/create_test.go
@@ -1,0 +1,201 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	ttesting "github.com/tektoncd/pipeline/pkg/reconciler/testing"
+	"github.com/tektoncd/pipeline/test"
+)
+
+func TestCreateOperations(t *testing.T) {
+	ctx, _ := ttesting.SetupFakeContext(t)
+
+	// No need to seed data for create operations
+	data := test.Data{}
+	_, _ = test.SeedTestData(t, ctx, data)
+
+	ss, cs := newSession(t, ctx)
+	defer ss.Close()
+	defer cs.Close()
+
+	pipelineYAML := `
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-pipeline
+spec:
+  tasks:
+  - name: hello
+    taskSpec:
+      steps:
+      - image: alpine
+        script: echo hello`
+
+	taskYAML := `
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: test-task
+spec:
+  steps:
+  - image: alpine
+    script: echo hello`
+
+	pipelineRunYAML := `
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: test-pipelinerun
+spec:
+  pipelineRef:
+    name: test-pipeline`
+
+	taskRunYAML := `
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  name: test-taskrun
+spec:
+  taskRef:
+    name: test-task`
+
+	tests := []struct {
+		name     string
+		tool     string
+		args     map[string]interface{}
+		expected string
+	}{
+		{
+			name: "create_pipeline",
+			tool: "create_pipeline",
+			args: map[string]interface{}{
+				"namespace": "default",
+				"yaml":      pipelineYAML,
+			},
+			expected: "Pipeline 'test-pipeline' created successfully",
+		},
+		{
+			name: "create_task",
+			tool: "create_task",
+			args: map[string]interface{}{
+				"namespace": "default",
+				"yaml":      taskYAML,
+			},
+			expected: "Task 'test-task' created successfully",
+		},
+		{
+			name: "create_pipelinerun_with_yaml",
+			tool: "create_pipelinerun",
+			args: map[string]interface{}{
+				"namespace": "default",
+				"yaml":      pipelineRunYAML,
+			},
+			expected: "PipelineRun 'test-pipelinerun' created successfully",
+		},
+		{
+			name: "create_taskrun_with_yaml",
+			tool: "create_taskrun",
+			args: map[string]interface{}{
+				"namespace": "default",
+				"yaml":      taskRunYAML,
+			},
+			expected: "TaskRun 'test-taskrun' created successfully",
+		},
+		{
+			name: "create_pipelinerun_with_generateName",
+			tool: "create_pipelinerun",
+			args: map[string]interface{}{
+				"namespace":    "default",
+				"generateName": "generated-pr-",
+			},
+			expected: "PipelineRun '' created successfully", // Empty name since generateName doesn't work in test
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			response, err := cs.CallTool(ctx, &mcp.CallToolParams{
+				Name:      test.tool,
+				Arguments: test.args,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			content, ok := response.Content[0].(*mcp.TextContent)
+			if !ok {
+				t.Fatal("Expected text content")
+			}
+
+			if !strings.Contains(content.Text, test.expected) {
+				t.Fatalf("Expected response to contain '%s', got '%s'", test.expected, content.Text)
+			}
+		})
+	}
+}
+
+func TestCreateOperationsErrors(t *testing.T) {
+	ctx, _ := ttesting.SetupFakeContext(t)
+	data := test.Data{}
+	_, _ = test.SeedTestData(t, ctx, data)
+
+	ss, cs := newSession(t, ctx)
+	defer ss.Close()
+	defer cs.Close()
+
+	tests := []struct {
+		name     string
+		tool     string
+		args     map[string]interface{}
+		expected string
+	}{
+		{
+			name: "create_pipeline_invalid_yaml",
+			tool: "create_pipeline",
+			args: map[string]interface{}{
+				"namespace": "default",
+				"yaml":      "invalid yaml content",
+			},
+			expected: "Error parsing YAML",
+		},
+		{
+			name: "create_pipeline_missing_yaml",
+			tool: "create_pipeline",
+			args: map[string]interface{}{
+				"namespace": "default",
+			},
+			expected: "Error: YAML definition is required",
+		},
+		{
+			name: "create_pipelinerun_missing_both",
+			tool: "create_pipelinerun",
+			args: map[string]interface{}{
+				"namespace": "default",
+			},
+			expected: "Error: Either YAML definition or generateName is required",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			response, err := cs.CallTool(ctx, &mcp.CallToolParams{
+				Name:      test.tool,
+				Arguments: test.args,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			content, ok := response.Content[0].(*mcp.TextContent)
+			if !ok {
+				t.Fatal("Expected text content")
+			}
+
+			if !strings.Contains(content.Text, test.expected) {
+				t.Fatalf("Expected error message to contain '%s', got '%s'", test.expected, content.Text)
+			}
+		})
+	}
+}

--- a/internal/tools/delete.go
+++ b/internal/tools/delete.go
@@ -1,0 +1,257 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/jsonschema"
+	mcp "github.com/modelcontextprotocol/go-sdk/mcp"
+	pipelineclient "github.com/tektoncd/pipeline/pkg/client/injection/client"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type deletePipelineParams struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+}
+
+func deletePipeline() (*mcp.ServerTool, error) {
+	scheme, err := jsonschema.For[deletePipelineParams]()
+	if err != nil {
+		return nil, err
+	}
+
+	scheme.Properties["name"].Description = "Name of the Pipeline to delete"
+	scheme.Properties["namespace"].Description = "Namespace of the Pipeline"
+	scheme.Properties["namespace"].Default = json.RawMessage(`"default"`)
+	scheme.Required = []string{"name"}
+
+	return mcp.NewServerTool(
+		"delete_pipeline",
+		"Delete a Pipeline",
+		handlerDeletePipeline,
+		mcp.Input(mcp.Schema(scheme)),
+	), nil
+}
+
+func handlerDeletePipeline(
+	ctx context.Context,
+	_ *mcp.ServerSession,
+	params *mcp.CallToolParamsFor[deletePipelineParams],
+) (*mcp.CallToolResultFor[string], error) {
+	name := params.Arguments.Name
+	namespace := params.Arguments.Namespace
+	if namespace == "" {
+		namespace = defaultNamespace
+	}
+
+	if name == "" {
+		return result("Error: Pipeline name is required"), nil
+	}
+
+	pipelineClient := pipelineclient.Get(ctx)
+	err := pipelineClient.TektonV1().Pipelines(namespace).Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil {
+		return result(fmt.Sprintf("Error deleting Pipeline: %v", err)), nil
+	}
+
+	return result(fmt.Sprintf("Pipeline '%s' deleted successfully from namespace '%s'", name, namespace)), nil
+}
+
+type deleteTaskParams struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+}
+
+func deleteTask() (*mcp.ServerTool, error) {
+	scheme, err := jsonschema.For[deleteTaskParams]()
+	if err != nil {
+		return nil, err
+	}
+
+	scheme.Properties["name"].Description = "Name of the Task to delete"
+	scheme.Properties["namespace"].Description = "Namespace of the Task"
+	scheme.Properties["namespace"].Default = json.RawMessage(`"default"`)
+	scheme.Required = []string{"name"}
+
+	return mcp.NewServerTool(
+		"delete_task",
+		"Delete a Task",
+		handlerDeleteTask,
+		mcp.Input(mcp.Schema(scheme)),
+	), nil
+}
+
+func handlerDeleteTask(
+	ctx context.Context,
+	_ *mcp.ServerSession,
+	params *mcp.CallToolParamsFor[deleteTaskParams],
+) (*mcp.CallToolResultFor[string], error) {
+	name := params.Arguments.Name
+	namespace := params.Arguments.Namespace
+	if namespace == "" {
+		namespace = defaultNamespace
+	}
+
+	if name == "" {
+		return result("Error: Task name is required"), nil
+	}
+
+	pipelineClient := pipelineclient.Get(ctx)
+	err := pipelineClient.TektonV1().Tasks(namespace).Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil {
+		return result(fmt.Sprintf("Error deleting Task: %v", err)), nil
+	}
+
+	return result(fmt.Sprintf("Task '%s' deleted successfully from namespace '%s'", name, namespace)), nil
+}
+
+type deletePipelineRunParams struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+}
+
+func deletePipelineRun() (*mcp.ServerTool, error) {
+	scheme, err := jsonschema.For[deletePipelineRunParams]()
+	if err != nil {
+		return nil, err
+	}
+
+	scheme.Properties["name"].Description = "Name of the PipelineRun to delete"
+	scheme.Properties["namespace"].Description = "Namespace of the PipelineRun"
+	scheme.Properties["namespace"].Default = json.RawMessage(`"default"`)
+	scheme.Required = []string{"name"}
+
+	return mcp.NewServerTool(
+		"delete_pipelinerun",
+		"Delete a PipelineRun",
+		handlerDeletePipelineRun,
+		mcp.Input(mcp.Schema(scheme)),
+	), nil
+}
+
+func handlerDeletePipelineRun(
+	ctx context.Context,
+	_ *mcp.ServerSession,
+	params *mcp.CallToolParamsFor[deletePipelineRunParams],
+) (*mcp.CallToolResultFor[string], error) {
+	name := params.Arguments.Name
+	namespace := params.Arguments.Namespace
+	if namespace == "" {
+		namespace = defaultNamespace
+	}
+
+	if name == "" {
+		return result("Error: PipelineRun name is required"), nil
+	}
+
+	pipelineClient := pipelineclient.Get(ctx)
+	err := pipelineClient.TektonV1().PipelineRuns(namespace).Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil {
+		return result(fmt.Sprintf("Error deleting PipelineRun: %v", err)), nil
+	}
+
+	return result(fmt.Sprintf("PipelineRun '%s' deleted successfully from namespace '%s'", name, namespace)), nil
+}
+
+type deleteTaskRunParams struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+}
+
+func deleteTaskRun() (*mcp.ServerTool, error) {
+	scheme, err := jsonschema.For[deleteTaskRunParams]()
+	if err != nil {
+		return nil, err
+	}
+
+	scheme.Properties["name"].Description = "Name of the TaskRun to delete"
+	scheme.Properties["namespace"].Description = "Namespace of the TaskRun"
+	scheme.Properties["namespace"].Default = json.RawMessage(`"default"`)
+	scheme.Required = []string{"name"}
+
+	return mcp.NewServerTool(
+		"delete_taskrun",
+		"Delete a TaskRun",
+		handlerDeleteTaskRun,
+		mcp.Input(mcp.Schema(scheme)),
+	), nil
+}
+
+func handlerDeleteTaskRun(
+	ctx context.Context,
+	_ *mcp.ServerSession,
+	params *mcp.CallToolParamsFor[deleteTaskRunParams],
+) (*mcp.CallToolResultFor[string], error) {
+	name := params.Arguments.Name
+	namespace := params.Arguments.Namespace
+	if namespace == "" {
+		namespace = defaultNamespace
+	}
+
+	if name == "" {
+		return result("Error: TaskRun name is required"), nil
+	}
+
+	pipelineClient := pipelineclient.Get(ctx)
+	err := pipelineClient.TektonV1().TaskRuns(namespace).Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil {
+		return result(fmt.Sprintf("Error deleting TaskRun: %v", err)), nil
+	}
+
+	return result(fmt.Sprintf("TaskRun '%s' deleted successfully from namespace '%s'", name, namespace)), nil
+}
+
+type deleteAllPipelineRunsParams struct {
+	Namespace     string `json:"namespace"`
+	LabelSelector string `json:"labelSelector"`
+	FieldSelector string `json:"fieldSelector"`
+}
+
+func deleteAllPipelineRuns() (*mcp.ServerTool, error) {
+	scheme, err := jsonschema.For[deleteAllPipelineRunsParams]()
+	if err != nil {
+		return nil, err
+	}
+
+	scheme.Properties["namespace"].Description = "Namespace to delete PipelineRuns from"
+	scheme.Properties["namespace"].Default = json.RawMessage(`"default"`)
+	scheme.Properties["labelSelector"].Description = "Label selector to filter PipelineRuns to delete"
+	scheme.Properties["fieldSelector"].Description = "Field selector to filter PipelineRuns to delete"
+
+	return mcp.NewServerTool(
+		"delete_all_pipelineruns",
+		"Delete multiple PipelineRuns based on selectors",
+		handlerDeleteAllPipelineRuns,
+		mcp.Input(mcp.Schema(scheme)),
+	), nil
+}
+
+func handlerDeleteAllPipelineRuns(
+	ctx context.Context,
+	_ *mcp.ServerSession,
+	params *mcp.CallToolParamsFor[deleteAllPipelineRunsParams],
+) (*mcp.CallToolResultFor[string], error) {
+	namespace := params.Arguments.Namespace
+	if namespace == "" {
+		namespace = defaultNamespace
+	}
+	labelSelector := params.Arguments.LabelSelector
+	fieldSelector := params.Arguments.FieldSelector
+
+	pipelineClient := pipelineclient.Get(ctx)
+
+	deleteOptions := metav1.DeleteOptions{}
+	listOptions := metav1.ListOptions{
+		LabelSelector: labelSelector,
+		FieldSelector: fieldSelector,
+	}
+
+	err := pipelineClient.TektonV1().PipelineRuns(namespace).DeleteCollection(ctx, deleteOptions, listOptions)
+	if err != nil {
+		return result(fmt.Sprintf("Error deleting PipelineRuns: %v", err)), nil
+	}
+
+	return result(fmt.Sprintf("PipelineRuns deleted successfully from namespace '%s' with selectors", namespace)), nil
+}

--- a/internal/tools/delete_test.go
+++ b/internal/tools/delete_test.go
@@ -1,0 +1,212 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	ttesting "github.com/tektoncd/pipeline/pkg/reconciler/testing"
+	"github.com/tektoncd/pipeline/test"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestDeleteOperations(t *testing.T) {
+	data := test.Data{
+		Pipelines: []*v1.Pipeline{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pipeline",
+					Namespace: "default",
+				},
+			},
+		},
+		Tasks: []*v1.Task{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-task",
+					Namespace: "default",
+				},
+			},
+		},
+		PipelineRuns: []*v1.PipelineRun{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pipelinerun",
+					Namespace: "default",
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pipelinerun-2",
+					Namespace: "default",
+					Labels: map[string]string{
+						"app": "test",
+					},
+				},
+			},
+		},
+		TaskRuns: []*v1.TaskRun{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-taskrun",
+					Namespace: "default",
+				},
+			},
+		},
+	}
+
+	ctx, _ := ttesting.SetupFakeContext(t)
+	_, _ = test.SeedTestData(t, ctx, data)
+
+	ss, cs := newSession(t, ctx)
+	defer ss.Close()
+	defer cs.Close()
+
+	tests := []struct {
+		name     string
+		tool     string
+		args     map[string]interface{}
+		expected string
+	}{
+		{
+			name: "delete_pipeline",
+			tool: "delete_pipeline",
+			args: map[string]interface{}{
+				"name":      "test-pipeline",
+				"namespace": "default",
+			},
+			expected: "Pipeline 'test-pipeline' deleted successfully",
+		},
+		{
+			name: "delete_task",
+			tool: "delete_task",
+			args: map[string]interface{}{
+				"name":      "test-task",
+				"namespace": "default",
+			},
+			expected: "Task 'test-task' deleted successfully",
+		},
+		{
+			name: "delete_pipelinerun",
+			tool: "delete_pipelinerun",
+			args: map[string]interface{}{
+				"name":      "test-pipelinerun",
+				"namespace": "default",
+			},
+			expected: "PipelineRun 'test-pipelinerun' deleted successfully",
+		},
+		{
+			name: "delete_taskrun",
+			tool: "delete_taskrun",
+			args: map[string]interface{}{
+				"name":      "test-taskrun",
+				"namespace": "default",
+			},
+			expected: "TaskRun 'test-taskrun' deleted successfully",
+		},
+		{
+			name: "delete_all_pipelineruns_with_label",
+			tool: "delete_all_pipelineruns",
+			args: map[string]interface{}{
+				"namespace":     "default",
+				"labelSelector": "app=test",
+			},
+			expected: "PipelineRuns deleted successfully from namespace 'default' with selectors",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			response, err := cs.CallTool(ctx, &mcp.CallToolParams{
+				Name:      test.tool,
+				Arguments: test.args,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			content, ok := response.Content[0].(*mcp.TextContent)
+			if !ok {
+				t.Fatal("Expected text content")
+			}
+
+			if !strings.Contains(content.Text, test.expected) {
+				t.Fatalf("Expected response to contain '%s', got '%s'", test.expected, content.Text)
+			}
+		})
+	}
+}
+
+func TestDeleteOperationsErrors(t *testing.T) {
+	ctx, _ := ttesting.SetupFakeContext(t)
+	data := test.Data{}
+	_, _ = test.SeedTestData(t, ctx, data)
+
+	ss, cs := newSession(t, ctx)
+	defer ss.Close()
+	defer cs.Close()
+
+	tests := []struct {
+		name     string
+		tool     string
+		args     map[string]interface{}
+		expected string
+	}{
+		{
+			name: "delete_pipeline_not_found",
+			tool: "delete_pipeline",
+			args: map[string]interface{}{
+				"name":      "nonexistent",
+				"namespace": "default",
+			},
+			expected: "Error deleting Pipeline",
+		},
+		{
+			name: "delete_pipeline_missing_name",
+			tool: "delete_pipeline",
+			args: map[string]interface{}{
+				"namespace": "default",
+			},
+			expected: "Error: Pipeline name is required",
+		},
+		{
+			name: "delete_task_not_found",
+			tool: "delete_task",
+			args: map[string]interface{}{
+				"name":      "nonexistent",
+				"namespace": "default",
+			},
+			expected: "Error deleting Task",
+		},
+		{
+			name: "delete_pipelinerun_missing_name",
+			tool: "delete_pipelinerun",
+			args: map[string]interface{}{
+				"namespace": "default",
+			},
+			expected: "Error: PipelineRun name is required",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			response, err := cs.CallTool(ctx, &mcp.CallToolParams{
+				Name:      test.tool,
+				Arguments: test.args,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			content, ok := response.Content[0].(*mcp.TextContent)
+			if !ok {
+				t.Fatal("Expected text content")
+			}
+
+			if !strings.Contains(content.Text, test.expected) {
+				t.Fatalf("Expected error message to contain '%s', got '%s'", test.expected, content.Text)
+			}
+		})
+	}
+}

--- a/internal/tools/get.go
+++ b/internal/tools/get.go
@@ -1,0 +1,299 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/jsonschema"
+	mcp "github.com/modelcontextprotocol/go-sdk/mcp"
+	pipelineclient "github.com/tektoncd/pipeline/pkg/client/injection/client"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+)
+
+const (
+	outputFormatDescription = "Output format (json or yaml)"
+	outputFormatYAML        = "yaml"
+	outputFormatJSON        = "json"
+)
+
+type getPipelineParams struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+	Output    string `json:"output"`
+}
+
+func getPipeline() (*mcp.ServerTool, error) {
+	scheme, err := jsonschema.For[getPipelineParams]()
+	if err != nil {
+		return nil, err
+	}
+
+	scheme.Properties["name"].Description = "Name of the Pipeline to get"
+	scheme.Properties["namespace"].Description = "Namespace of the Pipeline"
+	scheme.Properties["namespace"].Default = json.RawMessage(`"default"`)
+	scheme.Properties["output"].Description = outputFormatDescription
+	scheme.Properties["output"].Default = json.RawMessage(`"yaml"`)
+	scheme.Required = []string{"name"}
+
+	return mcp.NewServerTool(
+		"get_pipeline",
+		"Get a specific Pipeline by name",
+		handlerGetPipeline,
+		mcp.Input(mcp.Schema(scheme)),
+	), nil
+}
+
+func handlerGetPipeline(
+	ctx context.Context,
+	_ *mcp.ServerSession,
+	params *mcp.CallToolParamsFor[getPipelineParams],
+) (*mcp.CallToolResultFor[string], error) {
+	name := params.Arguments.Name
+	namespace := params.Arguments.Namespace
+	if namespace == "" {
+		namespace = defaultNamespace
+	}
+	output := params.Arguments.Output
+	if output == "" {
+		output = outputFormatYAML
+	}
+
+	if name == "" {
+		return result("Error: Pipeline name is required"), nil
+	}
+
+	pipelineClient := pipelineclient.Get(ctx)
+	pipeline, err := pipelineClient.TektonV1().Pipelines(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return result(fmt.Sprintf("Error getting Pipeline: %v", err)), nil
+	}
+
+	var outputStr string
+	if output == outputFormatJSON {
+		jsonData, err := json.MarshalIndent(pipeline, "", "  ")
+		if err != nil {
+			return result(fmt.Sprintf("Error marshaling to JSON: %v", err)), nil
+		}
+		outputStr = string(jsonData)
+	} else {
+		yamlData, err := yaml.Marshal(pipeline)
+		if err != nil {
+			return result(fmt.Sprintf("Error marshaling to YAML: %v", err)), nil
+		}
+		outputStr = string(yamlData)
+	}
+
+	return result(outputStr), nil
+}
+
+type getTaskParams struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+	Output    string `json:"output"`
+}
+
+func getTask() (*mcp.ServerTool, error) {
+	scheme, err := jsonschema.For[getTaskParams]()
+	if err != nil {
+		return nil, err
+	}
+
+	scheme.Properties["name"].Description = "Name of the Task to get"
+	scheme.Properties["namespace"].Description = "Namespace of the Task"
+	scheme.Properties["namespace"].Default = json.RawMessage(`"default"`)
+	scheme.Properties["output"].Description = outputFormatDescription
+	scheme.Properties["output"].Default = json.RawMessage(`"yaml"`)
+	scheme.Required = []string{"name"}
+
+	return mcp.NewServerTool(
+		"get_task",
+		"Get a specific Task by name",
+		handlerGetTask,
+		mcp.Input(mcp.Schema(scheme)),
+	), nil
+}
+
+func handlerGetTask(
+	ctx context.Context,
+	_ *mcp.ServerSession,
+	params *mcp.CallToolParamsFor[getTaskParams],
+) (*mcp.CallToolResultFor[string], error) {
+	name := params.Arguments.Name
+	namespace := params.Arguments.Namespace
+	if namespace == "" {
+		namespace = defaultNamespace
+	}
+	output := params.Arguments.Output
+	if output == "" {
+		output = outputFormatYAML
+	}
+
+	if name == "" {
+		return result("Error: Task name is required"), nil
+	}
+
+	pipelineClient := pipelineclient.Get(ctx)
+	task, err := pipelineClient.TektonV1().Tasks(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return result(fmt.Sprintf("Error getting Task: %v", err)), nil
+	}
+
+	var outputStr string
+	if output == outputFormatJSON {
+		jsonData, err := json.MarshalIndent(task, "", "  ")
+		if err != nil {
+			return result(fmt.Sprintf("Error marshaling to JSON: %v", err)), nil
+		}
+		outputStr = string(jsonData)
+	} else {
+		yamlData, err := yaml.Marshal(task)
+		if err != nil {
+			return result(fmt.Sprintf("Error marshaling to YAML: %v", err)), nil
+		}
+		outputStr = string(yamlData)
+	}
+
+	return result(outputStr), nil
+}
+
+type getPipelineRunParams struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+	Output    string `json:"output"`
+}
+
+func getPipelineRun() (*mcp.ServerTool, error) {
+	scheme, err := jsonschema.For[getPipelineRunParams]()
+	if err != nil {
+		return nil, err
+	}
+
+	scheme.Properties["name"].Description = "Name of the PipelineRun to get"
+	scheme.Properties["namespace"].Description = "Namespace of the PipelineRun"
+	scheme.Properties["namespace"].Default = json.RawMessage(`"default"`)
+	scheme.Properties["output"].Description = outputFormatDescription
+	scheme.Properties["output"].Default = json.RawMessage(`"yaml"`)
+	scheme.Required = []string{"name"}
+
+	return mcp.NewServerTool(
+		"get_pipelinerun",
+		"Get a specific PipelineRun by name",
+		handlerGetPipelineRun,
+		mcp.Input(mcp.Schema(scheme)),
+	), nil
+}
+
+func handlerGetPipelineRun(
+	ctx context.Context,
+	_ *mcp.ServerSession,
+	params *mcp.CallToolParamsFor[getPipelineRunParams],
+) (*mcp.CallToolResultFor[string], error) {
+	name := params.Arguments.Name
+	namespace := params.Arguments.Namespace
+	if namespace == "" {
+		namespace = defaultNamespace
+	}
+	output := params.Arguments.Output
+	if output == "" {
+		output = outputFormatYAML
+	}
+
+	if name == "" {
+		return result("Error: PipelineRun name is required"), nil
+	}
+
+	pipelineClient := pipelineclient.Get(ctx)
+	pipelineRun, err := pipelineClient.TektonV1().PipelineRuns(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return result(fmt.Sprintf("Error getting PipelineRun: %v", err)), nil
+	}
+
+	var outputStr string
+	if output == outputFormatJSON {
+		jsonData, err := json.MarshalIndent(pipelineRun, "", "  ")
+		if err != nil {
+			return result(fmt.Sprintf("Error marshaling to JSON: %v", err)), nil
+		}
+		outputStr = string(jsonData)
+	} else {
+		yamlData, err := yaml.Marshal(pipelineRun)
+		if err != nil {
+			return result(fmt.Sprintf("Error marshaling to YAML: %v", err)), nil
+		}
+		outputStr = string(yamlData)
+	}
+
+	return result(outputStr), nil
+}
+
+type getTaskRunParams struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+	Output    string `json:"output"`
+}
+
+func getTaskRun() (*mcp.ServerTool, error) {
+	scheme, err := jsonschema.For[getTaskRunParams]()
+	if err != nil {
+		return nil, err
+	}
+
+	scheme.Properties["name"].Description = "Name of the TaskRun to get"
+	scheme.Properties["namespace"].Description = "Namespace of the TaskRun"
+	scheme.Properties["namespace"].Default = json.RawMessage(`"default"`)
+	scheme.Properties["output"].Description = outputFormatDescription
+	scheme.Properties["output"].Default = json.RawMessage(`"yaml"`)
+	scheme.Required = []string{"name"}
+
+	return mcp.NewServerTool(
+		"get_taskrun",
+		"Get a specific TaskRun by name",
+		handlerGetTaskRun,
+		mcp.Input(mcp.Schema(scheme)),
+	), nil
+}
+
+func handlerGetTaskRun(
+	ctx context.Context,
+	_ *mcp.ServerSession,
+	params *mcp.CallToolParamsFor[getTaskRunParams],
+) (*mcp.CallToolResultFor[string], error) {
+	name := params.Arguments.Name
+	namespace := params.Arguments.Namespace
+	if namespace == "" {
+		namespace = defaultNamespace
+	}
+	output := params.Arguments.Output
+	if output == "" {
+		output = outputFormatYAML
+	}
+
+	if name == "" {
+		return result("Error: TaskRun name is required"), nil
+	}
+
+	pipelineClient := pipelineclient.Get(ctx)
+	taskRun, err := pipelineClient.TektonV1().TaskRuns(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return result(fmt.Sprintf("Error getting TaskRun: %v", err)), nil
+	}
+
+	var outputStr string
+	if output == outputFormatJSON {
+		jsonData, err := json.MarshalIndent(taskRun, "", "  ")
+		if err != nil {
+			return result(fmt.Sprintf("Error marshaling to JSON: %v", err)), nil
+		}
+		outputStr = string(jsonData)
+	} else {
+		yamlData, err := yaml.Marshal(taskRun)
+		if err != nil {
+			return result(fmt.Sprintf("Error marshaling to YAML: %v", err)), nil
+		}
+		outputStr = string(yamlData)
+	}
+
+	return result(outputStr), nil
+}

--- a/internal/tools/get_test.go
+++ b/internal/tools/get_test.go
@@ -1,0 +1,218 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	ttesting "github.com/tektoncd/pipeline/pkg/reconciler/testing"
+	"github.com/tektoncd/pipeline/test"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGetOperations(t *testing.T) {
+	data := test.Data{
+		Pipelines: []*v1.Pipeline{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pipeline",
+					Namespace: "default",
+				},
+				Spec: v1.PipelineSpec{
+					Description: "Test pipeline for get operation",
+				},
+			},
+		},
+		Tasks: []*v1.Task{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-task",
+					Namespace: "default",
+				},
+				Spec: v1.TaskSpec{
+					Description: "Test task for get operation",
+				},
+			},
+		},
+		PipelineRuns: []*v1.PipelineRun{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pipelinerun",
+					Namespace: "default",
+				},
+				Spec: v1.PipelineRunSpec{
+					PipelineRef: &v1.PipelineRef{
+						Name: "test-pipeline",
+					},
+				},
+			},
+		},
+		TaskRuns: []*v1.TaskRun{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-taskrun",
+					Namespace: "default",
+				},
+				Spec: v1.TaskRunSpec{
+					TaskRef: &v1.TaskRef{
+						Name: "test-task",
+					},
+				},
+			},
+		},
+	}
+
+	ctx, _ := ttesting.SetupFakeContext(t)
+	_, _ = test.SeedTestData(t, ctx, data)
+
+	ss, cs := newSession(t, ctx)
+	defer ss.Close()
+	defer cs.Close()
+
+	tests := []struct {
+		name     string
+		tool     string
+		args     map[string]interface{}
+		contains []string
+	}{
+		{
+			name: "get_pipeline_yaml",
+			tool: "get_pipeline",
+			args: map[string]interface{}{
+				"name":      "test-pipeline",
+				"namespace": "default",
+				"output":    "yaml",
+			},
+			contains: []string{"name: test-pipeline", "Test pipeline for get operation"},
+		},
+		{
+			name: "get_pipeline_json",
+			tool: "get_pipeline",
+			args: map[string]interface{}{
+				"name":      "test-pipeline",
+				"namespace": "default",
+				"output":    "json",
+			},
+			contains: []string{`"name": "test-pipeline"`, `"description": "Test pipeline for get operation"`},
+		},
+		{
+			name: "get_task_yaml",
+			tool: "get_task",
+			args: map[string]interface{}{
+				"name":      "test-task",
+				"namespace": "default",
+				"output":    "yaml",
+			},
+			contains: []string{"name: test-task", "Test task for get operation"},
+		},
+		{
+			name: "get_pipelinerun_yaml",
+			tool: "get_pipelinerun",
+			args: map[string]interface{}{
+				"name":      "test-pipelinerun",
+				"namespace": "default",
+				"output":    "yaml",
+			},
+			contains: []string{"name: test-pipelinerun", "pipelineRef:"},
+		},
+		{
+			name: "get_taskrun_yaml",
+			tool: "get_taskrun",
+			args: map[string]interface{}{
+				"name":      "test-taskrun",
+				"namespace": "default",
+				"output":    "yaml",
+			},
+			contains: []string{"name: test-taskrun", "taskRef:"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			response, err := cs.CallTool(ctx, &mcp.CallToolParams{
+				Name:      test.tool,
+				Arguments: test.args,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			content, ok := response.Content[0].(*mcp.TextContent)
+			if !ok {
+				t.Fatal("Expected text content")
+			}
+
+			for _, expected := range test.contains {
+				if !strings.Contains(content.Text, expected) {
+					t.Fatalf("Expected response to contain '%s', got '%s'", expected, content.Text)
+				}
+			}
+		})
+	}
+}
+
+func TestGetOperationsErrors(t *testing.T) {
+	ctx, _ := ttesting.SetupFakeContext(t)
+	data := test.Data{}
+	_, _ = test.SeedTestData(t, ctx, data)
+
+	ss, cs := newSession(t, ctx)
+	defer ss.Close()
+	defer cs.Close()
+
+	tests := []struct {
+		name     string
+		tool     string
+		args     map[string]interface{}
+		expected string
+	}{
+		{
+			name: "get_pipeline_not_found",
+			tool: "get_pipeline",
+			args: map[string]interface{}{
+				"name":      "nonexistent",
+				"namespace": "default",
+			},
+			expected: "Error getting Pipeline",
+		},
+		{
+			name: "get_task_missing_name",
+			tool: "get_task",
+			args: map[string]interface{}{
+				"namespace": "default",
+			},
+			expected: "Error: Task name is required",
+		},
+		{
+			name: "get_pipelinerun_not_found",
+			tool: "get_pipelinerun",
+			args: map[string]interface{}{
+				"name":      "nonexistent",
+				"namespace": "default",
+			},
+			expected: "Error getting PipelineRun",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			response, err := cs.CallTool(ctx, &mcp.CallToolParams{
+				Name:      test.tool,
+				Arguments: test.args,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			content, ok := response.Content[0].(*mcp.TextContent)
+			if !ok {
+				t.Fatal("Expected text content")
+			}
+
+			if !strings.Contains(content.Text, test.expected) {
+				t.Fatalf("Expected error message to contain '%s', got '%s'", test.expected, content.Text)
+			}
+		})
+	}
+}

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -6,7 +6,10 @@ import (
 	mcp "github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
+const defaultNamespace = "default"
+
 func Add(_ context.Context, s *mcp.Server) error {
+	// Start tools
 	startPipelineTool, err := startPipeline()
 	if err != nil {
 		return err
@@ -15,6 +18,8 @@ func Add(_ context.Context, s *mcp.Server) error {
 	if err != nil {
 		return err
 	}
+
+	// Restart tools
 	restartPipelineRunTool, err := restartPipelineRun()
 	if err != nil {
 		return err
@@ -23,12 +28,87 @@ func Add(_ context.Context, s *mcp.Server) error {
 	if err != nil {
 		return err
 	}
+
+	// Log tools
 	getTaskRunLogsTool, err := getTaskRunLogs()
 	if err != nil {
 		return err
 	}
 
+	// Create tools
+	createPipelineTool, err := createPipeline()
+	if err != nil {
+		return err
+	}
+	createTaskTool, err := createTask()
+	if err != nil {
+		return err
+	}
+	createPipelineRunTool, err := createPipelineRun()
+	if err != nil {
+		return err
+	}
+	createTaskRunTool, err := createTaskRun()
+	if err != nil {
+		return err
+	}
+
+	// Update tools
+	updatePipelineTool, err := updatePipeline()
+	if err != nil {
+		return err
+	}
+	updateTaskTool, err := updateTask()
+	if err != nil {
+		return err
+	}
+	patchPipelineTool, err := patchPipeline()
+	if err != nil {
+		return err
+	}
+
+	// Delete tools
+	deletePipelineTool, err := deletePipeline()
+	if err != nil {
+		return err
+	}
+	deleteTaskTool, err := deleteTask()
+	if err != nil {
+		return err
+	}
+	deletePipelineRunTool, err := deletePipelineRun()
+	if err != nil {
+		return err
+	}
+	deleteTaskRunTool, err := deleteTaskRun()
+	if err != nil {
+		return err
+	}
+	deleteAllPipelineRunsTool, err := deleteAllPipelineRuns()
+	if err != nil {
+		return err
+	}
+
+	// Get tools
+	getPipelineTool, err := getPipeline()
+	if err != nil {
+		return err
+	}
+	getTaskTool, err := getTask()
+	if err != nil {
+		return err
+	}
+	getPipelineRunTool, err := getPipelineRun()
+	if err != nil {
+		return err
+	}
+	getTaskRunTool, err := getTaskRun()
+	if err != nil {
+		return err
+	}
+
 	s.AddTools(
+		// Existing tools
 		startPipelineTool,
 		startTaskTool,
 		restartPipelineRunTool,
@@ -39,6 +119,30 @@ func Add(_ context.Context, s *mcp.Server) error {
 		listTaskRuns(),
 		listTasks(),
 		listStepactions(),
+
+		// Create operations
+		createPipelineTool,
+		createTaskTool,
+		createPipelineRunTool,
+		createTaskRunTool,
+
+		// Read/Get operations
+		getPipelineTool,
+		getTaskTool,
+		getPipelineRunTool,
+		getTaskRunTool,
+
+		// Update operations
+		updatePipelineTool,
+		updateTaskTool,
+		patchPipelineTool,
+
+		// Delete operations
+		deletePipelineTool,
+		deleteTaskTool,
+		deletePipelineRunTool,
+		deleteTaskRunTool,
+		deleteAllPipelineRunsTool,
 	)
 	return nil
 }

--- a/internal/tools/update.go
+++ b/internal/tools/update.go
@@ -1,0 +1,210 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/jsonschema"
+	mcp "github.com/modelcontextprotocol/go-sdk/mcp"
+	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	pipelineclient "github.com/tektoncd/pipeline/pkg/client/injection/client"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/yaml"
+)
+
+const (
+	namespacePipelineDescription = "Namespace of the Pipeline"
+	namespaceTaskDescription     = "Namespace of the Task"
+)
+
+type updatePipelineParams struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+	Yaml      string `json:"yaml"`
+}
+
+func updatePipeline() (*mcp.ServerTool, error) {
+	scheme, err := jsonschema.For[updatePipelineParams]()
+	if err != nil {
+		return nil, err
+	}
+
+	scheme.Properties["name"].Description = "Name of the Pipeline to update"
+	scheme.Properties["namespace"].Description = namespacePipelineDescription
+	scheme.Properties["namespace"].Default = json.RawMessage(`"default"`)
+	scheme.Properties["yaml"].Description = "Updated YAML definition of the Pipeline"
+	scheme.Required = []string{"name", "yaml"}
+
+	return mcp.NewServerTool(
+		"update_pipeline",
+		"Update an existing Pipeline",
+		handlerUpdatePipeline,
+		mcp.Input(mcp.Schema(scheme)),
+	), nil
+}
+
+func handlerUpdatePipeline(
+	ctx context.Context,
+	_ *mcp.ServerSession,
+	params *mcp.CallToolParamsFor[updatePipelineParams],
+) (*mcp.CallToolResultFor[string], error) {
+	name := params.Arguments.Name
+	namespace := params.Arguments.Namespace
+	if namespace == "" {
+		namespace = defaultNamespace
+	}
+	yamlStr := params.Arguments.Yaml
+
+	if name == "" || yamlStr == "" {
+		return result("Error: Name and YAML definition are required"), nil
+	}
+
+	var pipeline pipelinev1.Pipeline
+	if err := yaml.Unmarshal([]byte(yamlStr), &pipeline); err != nil {
+		return result(fmt.Sprintf("Error parsing YAML: %v", err)), nil
+	}
+
+	pipelineClient := pipelineclient.Get(ctx)
+
+	existing, err := pipelineClient.TektonV1().Pipelines(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return result(fmt.Sprintf("Error getting existing Pipeline: %v", err)), nil
+	}
+
+	pipeline.Name = name
+	pipeline.Namespace = namespace
+	pipeline.ResourceVersion = existing.ResourceVersion
+
+	updated, err := pipelineClient.TektonV1().Pipelines(namespace).Update(ctx, &pipeline, metav1.UpdateOptions{})
+	if err != nil {
+		return result(fmt.Sprintf("Error updating Pipeline: %v", err)), nil
+	}
+
+	return result(fmt.Sprintf("Pipeline '%s' updated successfully in namespace '%s'", updated.Name, namespace)), nil
+}
+
+type updateTaskParams struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+	Yaml      string `json:"yaml"`
+}
+
+func updateTask() (*mcp.ServerTool, error) {
+	scheme, err := jsonschema.For[updateTaskParams]()
+	if err != nil {
+		return nil, err
+	}
+
+	scheme.Properties["name"].Description = "Name of the Task to update"
+	scheme.Properties["namespace"].Description = namespaceTaskDescription
+	scheme.Properties["namespace"].Default = json.RawMessage(`"default"`)
+	scheme.Properties["yaml"].Description = "Updated YAML definition of the Task"
+	scheme.Required = []string{"name", "yaml"}
+
+	return mcp.NewServerTool(
+		"update_task",
+		"Update an existing Task",
+		handlerUpdateTask,
+		mcp.Input(mcp.Schema(scheme)),
+	), nil
+}
+
+func handlerUpdateTask(
+	ctx context.Context,
+	_ *mcp.ServerSession,
+	params *mcp.CallToolParamsFor[updateTaskParams],
+) (*mcp.CallToolResultFor[string], error) {
+	name := params.Arguments.Name
+	namespace := params.Arguments.Namespace
+	if namespace == "" {
+		namespace = defaultNamespace
+	}
+	yamlStr := params.Arguments.Yaml
+
+	if name == "" || yamlStr == "" {
+		return result("Error: Name and YAML definition are required"), nil
+	}
+
+	var task pipelinev1.Task
+	if err := yaml.Unmarshal([]byte(yamlStr), &task); err != nil {
+		return result(fmt.Sprintf("Error parsing YAML: %v", err)), nil
+	}
+
+	pipelineClient := pipelineclient.Get(ctx)
+
+	existing, err := pipelineClient.TektonV1().Tasks(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return result(fmt.Sprintf("Error getting existing Task: %v", err)), nil
+	}
+
+	task.Name = name
+	task.Namespace = namespace
+	task.ResourceVersion = existing.ResourceVersion
+
+	updated, err := pipelineClient.TektonV1().Tasks(namespace).Update(ctx, &task, metav1.UpdateOptions{})
+	if err != nil {
+		return result(fmt.Sprintf("Error updating Task: %v", err)), nil
+	}
+
+	return result(fmt.Sprintf("Task '%s' updated successfully in namespace '%s'", updated.Name, namespace)), nil
+}
+
+type patchPipelineParams struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+	Patch     string `json:"patch"`
+}
+
+func patchPipeline() (*mcp.ServerTool, error) {
+	scheme, err := jsonschema.For[patchPipelineParams]()
+	if err != nil {
+		return nil, err
+	}
+
+	scheme.Properties["name"].Description = "Name of the Pipeline to patch"
+	scheme.Properties["namespace"].Description = namespacePipelineDescription
+	scheme.Properties["namespace"].Default = json.RawMessage(`"default"`)
+	scheme.Properties["patch"].Description = "JSON patch to apply to the Pipeline"
+	scheme.Required = []string{"name", "patch"}
+
+	return mcp.NewServerTool(
+		"patch_pipeline",
+		"Apply a JSON patch to an existing Pipeline",
+		handlerPatchPipeline,
+		mcp.Input(mcp.Schema(scheme)),
+	), nil
+}
+
+func handlerPatchPipeline(
+	ctx context.Context,
+	_ *mcp.ServerSession,
+	params *mcp.CallToolParamsFor[patchPipelineParams],
+) (*mcp.CallToolResultFor[string], error) {
+	name := params.Arguments.Name
+	namespace := params.Arguments.Namespace
+	if namespace == "" {
+		namespace = defaultNamespace
+	}
+	patchStr := params.Arguments.Patch
+
+	if name == "" || patchStr == "" {
+		return result("Error: Name and patch are required"), nil
+	}
+
+	pipelineClient := pipelineclient.Get(ctx)
+
+	patched, err := pipelineClient.TektonV1().Pipelines(namespace).Patch(
+		ctx,
+		name,
+		types.JSONPatchType,
+		[]byte(patchStr),
+		metav1.PatchOptions{},
+	)
+	if err != nil {
+		return result(fmt.Sprintf("Error patching Pipeline: %v", err)), nil
+	}
+
+	return result(fmt.Sprintf("Pipeline '%s' patched successfully in namespace '%s'", patched.Name, namespace)), nil
+}

--- a/internal/tools/update_test.go
+++ b/internal/tools/update_test.go
@@ -1,0 +1,208 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	ttesting "github.com/tektoncd/pipeline/pkg/reconciler/testing"
+	"github.com/tektoncd/pipeline/test"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestUpdateOperations(t *testing.T) {
+	data := test.Data{
+		Pipelines: []*v1.Pipeline{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pipeline",
+					Namespace: "default",
+				},
+				Spec: v1.PipelineSpec{
+					Description: "Original description",
+				},
+			},
+		},
+		Tasks: []*v1.Task{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-task",
+					Namespace: "default",
+				},
+				Spec: v1.TaskSpec{
+					Description: "Original task description",
+				},
+			},
+		},
+	}
+
+	ctx, _ := ttesting.SetupFakeContext(t)
+	_, _ = test.SeedTestData(t, ctx, data)
+
+	ss, cs := newSession(t, ctx)
+	defer ss.Close()
+	defer cs.Close()
+
+	updatedPipelineYAML := `
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-pipeline
+spec:
+  description: Updated pipeline description
+  tasks:
+  - name: updated-task
+    taskSpec:
+      steps:
+      - image: alpine
+        script: echo updated`
+
+	updatedTaskYAML := `
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: test-task
+spec:
+  description: Updated task description
+  steps:
+  - image: alpine
+    script: echo updated`
+
+	tests := []struct {
+		name     string
+		tool     string
+		args     map[string]interface{}
+		expected string
+	}{
+		{
+			name: "update_pipeline",
+			tool: "update_pipeline",
+			args: map[string]interface{}{
+				"name":      "test-pipeline",
+				"namespace": "default",
+				"yaml":      updatedPipelineYAML,
+			},
+			expected: "Pipeline 'test-pipeline' updated successfully",
+		},
+		{
+			name: "update_task",
+			tool: "update_task",
+			args: map[string]interface{}{
+				"name":      "test-task",
+				"namespace": "default",
+				"yaml":      updatedTaskYAML,
+			},
+			expected: "Task 'test-task' updated successfully",
+		},
+		{
+			name: "patch_pipeline",
+			tool: "patch_pipeline",
+			args: map[string]interface{}{
+				"name":      "test-pipeline",
+				"namespace": "default",
+				"patch":     `[{"op": "replace", "path": "/spec/description", "value": "Patched description"}]`,
+			},
+			expected: "Pipeline 'test-pipeline' patched successfully",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			response, err := cs.CallTool(ctx, &mcp.CallToolParams{
+				Name:      test.tool,
+				Arguments: test.args,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			content, ok := response.Content[0].(*mcp.TextContent)
+			if !ok {
+				t.Fatal("Expected text content")
+			}
+
+			if !strings.Contains(content.Text, test.expected) {
+				t.Fatalf("Expected response to contain '%s', got '%s'", test.expected, content.Text)
+			}
+		})
+	}
+}
+
+func TestUpdateOperationsErrors(t *testing.T) {
+	ctx, _ := ttesting.SetupFakeContext(t)
+	data := test.Data{}
+	_, _ = test.SeedTestData(t, ctx, data)
+
+	ss, cs := newSession(t, ctx)
+	defer ss.Close()
+	defer cs.Close()
+
+	tests := []struct {
+		name     string
+		tool     string
+		args     map[string]interface{}
+		expected string
+	}{
+		{
+			name: "update_pipeline_not_found",
+			tool: "update_pipeline",
+			args: map[string]interface{}{
+				"name":      "nonexistent",
+				"namespace": "default",
+				"yaml":      "apiVersion: tekton.dev/v1\nkind: Pipeline\nmetadata:\n  name: test",
+			},
+			expected: "Error getting existing Pipeline",
+		},
+		{
+			name: "update_pipeline_invalid_yaml",
+			tool: "update_pipeline",
+			args: map[string]interface{}{
+				"name":      "test-pipeline",
+				"namespace": "default",
+				"yaml":      "invalid yaml content",
+			},
+			expected: "Error parsing YAML",
+		},
+		{
+			name: "update_pipeline_missing_yaml",
+			tool: "update_pipeline",
+			args: map[string]interface{}{
+				"name":      "test-pipeline",
+				"namespace": "default",
+			},
+			expected: "Error: Name and YAML definition are required",
+		},
+		{
+			name: "patch_pipeline_invalid_patch",
+			tool: "patch_pipeline",
+			args: map[string]interface{}{
+				"name":      "test-pipeline",
+				"namespace": "default",
+				"patch":     "invalid json patch",
+			},
+			expected: "Error patching Pipeline",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			response, err := cs.CallTool(ctx, &mcp.CallToolParams{
+				Name:      test.tool,
+				Arguments: test.args,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			content, ok := response.Content[0].(*mcp.TextContent)
+			if !ok {
+				t.Fatal("Expected text content")
+			}
+
+			if !strings.Contains(content.Text, test.expected) {
+				t.Fatalf("Expected error message to contain '%s', got '%s'", test.expected, content.Text)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

- Add create operations for Pipeline, Task, PipelineRun, TaskRun
- Add get operations for individual resources with JSON/YAML output
- Add update and patch operations for Pipeline and Task
- Add delete operations for all resource types
- Add bulk delete operation for PipelineRuns with selectors
- Update README with comprehensive documentation organized by operation type

fixes https://github.com/tektoncd/mcp-server/issues/20
partially fixes https://github.com/tektoncd/mcp-server/issues/3

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
