### PR TITLE
Nominate jbpratt as mcp-server approver and reviewer

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,10 +1,12 @@
 approvers:
+- jbpratt
 - vdemeester
 - chmouel
 - waveywaves
 - jkhelil
 
 reviewers:
+- jbpratt
 - savitaashture
 - anithapriyanatarajan
 - vdemeester


### PR DESCRIPTION
# Changes

Nominate **jbpratt** as mcp-server approver and reviewer. Most active non-maintainer contributor on the repo.

Per the [contributor ladder](https://github.com/tektoncd/community/blob/main/process/contributor-ladder.md#maintainer), the nominee must agree to all requirements by commenting on this PR.

## jbpratt — Activity (last 12 months)

| Metric | mcp-server | Org-wide |
|--------|------------|----------|
| DevStats contributions | 61 | 67 |
| PRs authored | 7 (6 merged) | 8 |
| PR reviews | 24 | 38 |
| Comments | 22 | — |
| Issues | 3 | 3 |

Most active non-maintainer on mcp-server. 24 PR reviews — second only to vdemeester (61). High merge rate (6/7 PRs merged).

## Maintainer Requirements Checklist

- [x] Active reviewing for 3+ months
- [x] Demonstrated knowledge of the project
- [ ] **Nominee**: please comment confirming you agree to all maintainer responsibilities

Full triage report: https://gist.github.com/vdemeester/c7ce8d4fea6f7a2f9b3f685558ce8ded

# Submitter Checklist

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md)
- [x] Release notes block below has been updated

# Release Notes

```release-note
NONE
```