### PR TITLE
security: remove unused Kubernetes permissions

### DIFF
--- a/config/300-rbac/role.yaml
+++ b/config/300-rbac/role.yaml
@@ -11,7 +11,7 @@ rules:
   - apiGroups: ["tekton.dev"]
     resources: ["tasks", "pipelines", "taskruns", "pipelineruns", "stepactions"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-  # Access to kubernetes resources
+  # Access to pods for TaskRun logs
   - apiGroups: [""]
-    resources: ["pods", "namespaces", "configmaps", "secrets"]
+    resources: ["pods"]
     verbs: ["get", "list", "watch"]


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Remove unused read access to Kubernetes Secrets, ConfigMaps, and Namespaces from the MCP Server ClusterRole.

Retain Pod read access, which is required by the TaskRun log tool. Source inspection found no use of the removed core Kubernetes resources.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
