### PR TITLE
test: add cluster-backed MCP smoke test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,13 +70,67 @@ jobs:
     - name: unit
       run: |
         go test -v -race -timeout 5m ./...
-  # e2e-tests:
-  #   needs: [build]
-  #   uses: ./.github/workflows/e2e-matrix.yml
+  e2e:
+    needs: [build]
+    name: e2e
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    env:
+      KO_DOCKER_REPO: registry.local:5000/mcp-server
+      TEKTON_PIPELINES_URL: https://github.com/tektoncd/pipeline/releases/download/v1.15.0/release.yaml
+      TEKTON_PIPELINES_SHA256: 9b1bfe474da43d4e7e9993e5c2b67ef0966b0a513de51f25087bc1118a5f49d3
+    steps:
+    - name: Harden runner
+      uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40  # v2.20.1
+      with:
+        egress-policy: audit
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      with:
+        persist-credentials: false
+    - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
+      with:
+        go-version-file: "go.mod"
+    - name: Set up kind
+      uses: chainguard-dev/actions/setup-kind@9d631658f55713e5f63ca0cc21ee168f81301fd9  # v1.6.30
+      with:
+        k8s-version: 1.34.x
+        kind-version: 0.32.0
+    - name: Set up ko
+      uses: ko-build/setup-ko@61b4d1d396f5b2e7d6bb6fefdce3dc38d1a13445  # v0.10
+      with:
+        version: v0.19.1
+    - name: Install Tekton Pipelines
+      run: |
+        manifest="$RUNNER_TEMP/tekton-pipelines-release.yaml"
+        curl --fail --location --retry 5 --output "$manifest" "$TEKTON_PIPELINES_URL"
+        echo "$TEKTON_PIPELINES_SHA256  $manifest" | sha256sum --check
+        kubectl apply --filename "$manifest"
+        kubectl wait --for=condition=Established crd/tasks.tekton.dev --timeout=2m
+        kubectl wait --for=condition=Available deployment --all --namespace tekton-pipelines --timeout=5m
+    - name: Deploy MCP Server
+      run: |
+        ko apply --insecure-registry --sbom=none -BRf config/
+        kubectl rollout status deployment/tekton-mcp-server --namespace tekton-mcp --timeout=5m
+        kubectl create namespace mcp-e2e
+    - name: Run MCP smoke test
+      run: |
+        kubectl port-forward --namespace tekton-mcp service/tekton-mcp-server 18080:8080 >"$RUNNER_TEMP/port-forward.log" 2>&1 &
+        port_forward_pid=$!
+        trap 'kill "$port_forward_pid"' EXIT
+        MCP_SERVER_URL=http://127.0.0.1:18080 E2E_NAMESPACE=mcp-e2e \
+          go test -v -tags=e2e -timeout=3m ./test/e2e
+    - name: Collect failure logs
+      if: failure()
+      run: |
+        kubectl get all --all-namespaces
+        kubectl logs deployment/tekton-mcp-server --namespace tekton-mcp || true
+        cat "$RUNNER_TEMP/port-forward.log" || true
 
   ci-summary:
     name: CI summary
-    needs: [build, linting, tests]
+    needs: [build, linting, tests, e2e]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -86,6 +140,7 @@ jobs:
           "build=${{ needs.build.result }}"
           "linting=${{ needs.linting.result }}"
           "tests=${{ needs.tests.result }}"
+          "e2e=${{ needs.e2e.result }}"
         )
         failed=0
         for r in "${results[@]}"; do

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -49,6 +49,15 @@ Run the same unit-test command used by CI:
 go test -v -race -timeout 5m ./...
 ```
 
+CI also deploys the server and Tekton Pipelines to kind. To run its MCP smoke
+test against an existing deployment:
+
+```shell
+kubectl create namespace mcp-e2e
+MCP_SERVER_URL=http://127.0.0.1:8080 E2E_NAMESPACE=mcp-e2e \
+  go test -v -tags=e2e -timeout=3m ./test/e2e
+```
+
 Before submitting a pull request, also run:
 
 ```shell

--- a/test/e2e/smoke_test.go
+++ b/test/e2e/smoke_test.go
@@ -1,0 +1,124 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func TestTools(t *testing.T) {
+	endpoint := os.Getenv("MCP_SERVER_URL")
+	namespace := os.Getenv("E2E_NAMESPACE")
+	if endpoint == "" || namespace == "" {
+		t.Fatal("MCP_SERVER_URL and E2E_NAMESPACE are required")
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
+	defer cancel()
+
+	session := connect(t, ctx, endpoint)
+	defer session.Close()
+
+	name := fmt.Sprintf("mcp-smoke-%d", time.Now().UnixNano())
+	created, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name: "create_task",
+		Arguments: map[string]any{
+			"namespace": namespace,
+			"yaml": fmt.Sprintf(`apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: %s
+spec:
+  steps:
+    - name: noop
+      image: busybox:1.36.1
+      command: ["true"]
+`, name),
+		},
+	})
+	if err != nil {
+		t.Fatalf("create_task: %v", err)
+	}
+	if text := resultText(t, created); created.IsError || !strings.Contains(text, "created successfully") {
+		t.Fatalf("create_task: %s", text)
+	}
+
+	deadline := time.Now().Add(30 * time.Second)
+	for {
+		listed, err := session.CallTool(ctx, &mcp.CallToolParams{
+			Name: "list_tasks",
+			Arguments: map[string]any{
+				"namespace": namespace,
+				"prefix":    name,
+			},
+		})
+		if err == nil && !listed.IsError && containsTask(resultText(t, listed), name) {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("list_tasks did not return %q: %v", name, err)
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatal(ctx.Err())
+		case <-time.After(time.Second):
+		}
+	}
+}
+
+func connect(t *testing.T, ctx context.Context, endpoint string) *mcp.ClientSession {
+	t.Helper()
+	deadline := time.Now().Add(30 * time.Second)
+	for {
+		client := mcp.NewClient("tekton-mcp-e2e", "dev", nil)
+		session, err := client.Connect(ctx, mcp.NewStreamableClientTransport(endpoint, nil))
+		if err == nil {
+			return session
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("connect to %s: %v", endpoint, err)
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatal(ctx.Err())
+		case <-time.After(time.Second):
+		}
+	}
+}
+
+func resultText(t *testing.T, result *mcp.CallToolResult) string {
+	t.Helper()
+	if len(result.Content) != 1 {
+		t.Fatalf("unexpected tool result: %#v", result.Content)
+	}
+	text, ok := result.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("unexpected tool result type: %T", result.Content[0])
+	}
+	return text.Text
+}
+
+func containsTask(text, name string) bool {
+	var tasks []struct {
+		Metadata struct {
+			Name string `json:"name"`
+		} `json:"metadata"`
+	}
+	if json.Unmarshal([]byte(text), &tasks) != nil {
+		return false
+	}
+	for _, task := range tasks {
+		if task.Metadata.Name == name {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Enable a required end-to-end smoke job in the existing CI summary.

The job creates a disposable kind cluster, verifies and installs the pinned Tekton Pipelines `v1.15.0` manifest, deploys MCP Server with `ko`, connects through Streamable HTTP using the existing Go MCP SDK, creates a Task, and confirms it through the list tool.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
